### PR TITLE
Fallback to null when array key is not set

### DIFF
--- a/src/Attribute/Country.php
+++ b/src/Attribute/Country.php
@@ -101,7 +101,7 @@ class Country extends BaseSimple
     protected function prepareTemplate(Template $objTemplate, $arrRowData, $objSettings)
     {
         parent::prepareTemplate($objTemplate, $arrRowData, $objSettings);
-        $objTemplate->value = $this->getCountryLabel($arrRowData[$this->getColName()]);
+        $objTemplate->value = $this->getCountryLabel(($arrRowData[$this->getColName()] ?? null));
     }
 
     /**


### PR DESCRIPTION
This may happen when we have cleared the value to `null` and the core then clears the array entry.
